### PR TITLE
Fix the ArangoDBDocumentManager implementation to shutdown the ArangoDB instance

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Update package name convention to `org.jnosql.databases.[DATABASE].[LAYER]`
 - Integrate the mapping layer on this repository
 
+=== Fixed
+
+- Fix the ArangoDBDocumentManager implementation to shut down the ArangoDB instance
+
 == [1.0.0-b6] - 2023-03-11
 
 === Changed

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/DefaultArangoDBDocumentManager.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/DefaultArangoDBDocumentManager.java
@@ -155,7 +155,7 @@ class DefaultArangoDBDocumentManager implements ArangoDBDocumentManager {
 
     @Override
     public void close() {
-
+        arangoDB.shutdown();
     }
 
 


### PR DESCRIPTION
Ref: https://github.com/eclipse/jnosql/issues/366

## Changes
- Fix the ArangoDBDocumentManager implementation to shutdown the ArangoDB instance; 