### PR TITLE
Fix issue #386

### DIFF
--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfiguration.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfiguration.java
@@ -80,6 +80,12 @@ public class ElasticsearchDocumentConfiguration implements DocumentConfiguration
 
     @Override
     public ElasticsearchDocumentManagerFactory apply(Settings settings) {
+        ElasticsearchClient elasticsearchClient = buildElasticsearchClient(settings);
+
+        return new ElasticsearchDocumentManagerFactory(elasticsearchClient);
+    }
+
+    public ElasticsearchClient buildElasticsearchClient(Settings settings) {
         requireNonNull(settings, "settings is required");
 
         settings.prefixSupplier(asList(ElasticsearchConfigurations.HOST, Configurations.HOST))
@@ -115,8 +121,7 @@ public class ElasticsearchDocumentConfiguration implements DocumentConfiguration
         var transport = new RestClientTransport(httpClient, new JsonbJsonpMapper());
 
         var elasticsearchClient = new ElasticsearchClient(transport);
-
-        return new ElasticsearchDocumentManagerFactory(elasticsearchClient);
+        return elasticsearchClient;
     }
 
 }

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchEntry.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchEntry.java
@@ -60,7 +60,8 @@ class ElasticsearchEntry {
         List<Document> documents = map.keySet().stream()
                 .map(k -> toDocument(k, map))
                 .collect(Collectors.toList());
-        DocumentEntity entity = DocumentEntity.of(collection, documents);
+        DocumentEntity entity = DocumentEntity.of(collection);
+        documents.forEach(d-> entity.add(d.name(),d.value()));
         entity.remove(EntityConverter.ID_FIELD);
         entity.remove(EntityConverter.ENTITY);
         entity.add(id);

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverter.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverter.java
@@ -16,11 +16,15 @@
 package org.eclipse.jnosql.databases.elasticsearch.communication;
 
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryStringQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord;
 import co.elastic.clients.json.JsonData;
 import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.TypeReference;
@@ -29,15 +33,15 @@ import org.eclipse.jnosql.communication.document.DocumentCondition;
 import org.eclipse.jnosql.communication.document.DocumentQuery;
 import org.eclipse.jnosql.communication.driver.ValueUtil;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.eclipse.jnosql.communication.Condition.EQUALS;
 import static org.eclipse.jnosql.communication.Condition.IN;
 
 final class QueryConverter {
@@ -47,17 +51,25 @@ final class QueryConverter {
     private QueryConverter() {
     }
 
-    static QueryConverterResult select(DocumentQuery query) {
-        List<String> ids = new ArrayList<>();
+    static QueryConverterResult select(ElasticsearchClient client, String database, DocumentQuery query) {
+
+        var indexMappingRecord = getIndexMappingRecord(client, database, query);
 
         Query.Builder nameCondition = Optional.of(query.name())
-                .map(collection -> new Query.Builder().term(q -> q
-                        .field(EntityConverter.ENTITY).value(collection)))
+                .map(collection -> {
+                    if (supportTermQuery(indexMappingRecord, EntityConverter.ENTITY)) {
+                        return new Query.Builder().term(q -> q
+                                .field(EntityConverter.ENTITY).value(collection));
+                    }
+                    return new Query.Builder().match(q -> q
+                            .field(EntityConverter.ENTITY).query(collection));
+
+                })
                 .map(Query.Builder.class::cast)
                 .orElse(null);
 
         Query.Builder queryConditions = query.condition()
-                .map(c -> getCondition(c, ids))
+                .map(c -> getCondition(indexMappingRecord, c))
                 .orElse(null);
 
 
@@ -67,31 +79,55 @@ final class QueryConverter {
                         .must(c1.build(), c2.build()))))
                 .orElse(null);
 
-        return new QueryConverterResult(builder, ids);
+        return new QueryConverterResult(builder);
 
     }
 
+    public static boolean supportTermQuery(IndexMappingRecord indexMappingRecord, String attribute) {
+        return supportTermQuery(indexMappingRecord.mappings().properties(), attribute);
+    }
 
-    private static Query.Builder getCondition(DocumentCondition condition, List<String> ids) {
-        Document document = condition.document();
-
-        if (!NOT_APPENDABLE.contains(condition.condition()) && isIdField(document)) {
-            if (IN.equals(condition.condition())) {
-                ids.addAll(document.get(new TypeReference<List<String>>() {
-                }));
-            } else if (EQUALS.equals(condition.condition())) {
-                ids.add(document.get(String.class));
+    public static boolean supportTermQuery(Map<String, Property> properties, String attribute) {
+        String attributeName = attribute;
+        if (attributeName.contains(".")) {
+            attributeName = attribute.substring(0, attribute.indexOf("."));
+            Property property = properties.get(attributeName);
+            if (Objects.nonNull(property) && property.isObject()) {
+                return supportTermQuery(property.object().properties(),
+                        attribute.substring(attribute.indexOf(".") + 1));
             }
-
-            return null;
+            return false;
         }
+        Property property = properties.get(attributeName);
+        return Objects.nonNull(property) && property.isKeyword();
+    }
+
+    private static IndexMappingRecord getIndexMappingRecord(ElasticsearchClient client, String database, DocumentQuery query) {
+        try {
+            return client.indices().getMapping(q -> q.index(database))
+                    .get(database);
+        } catch (IOException e) {
+            throw new IllegalStateException("cannot retrieve the index's mapping: %s".formatted(e.getMessage()), e);
+        }
+    }
+
+
+    private static Query.Builder getCondition(IndexMappingRecord indexMappingRecord, DocumentCondition condition) {
+        Document document = condition.document();
 
         switch (condition.condition()) {
             case EQUALS:
+                if (supportTermQuery(indexMappingRecord, document.name())) {
+                    return (Query.Builder) new Query.Builder()
+                            .term(TermQuery.of(tq -> tq
+                                    .field(document.name())
+                                    .value(v -> v
+                                            .anyValue(JsonData.of(document.value().get())))));
+                }
                 return (Query.Builder) new Query.Builder()
-                        .term(TermQuery.of(tq -> tq
+                        .match(MatchQuery.of(tq -> tq
                                 .field(document.name())
-                                .value(v -> v
+                                .query(v -> v
                                         .anyValue(JsonData.of(document.value().get())))));
             case LESSER_THAN:
                 return (Query.Builder) new Query.Builder()
@@ -122,10 +158,18 @@ final class QueryConverter {
             case IN:
                 return (Query.Builder) ValueUtil.convertToList(document.value())
                         .stream()
-                        .map(val -> new Query.Builder()
-                                .term(TermQuery.of(tq -> tq
-                                        .field(document.name())
-                                        .value(v -> v.anyValue(JsonData.of(val))))))
+                        .map(val -> {
+                            if (supportTermQuery(indexMappingRecord, document.name())) {
+                                return new Query.Builder()
+                                        .term(TermQuery.of(tq -> tq
+                                                .field(document.name())
+                                                .value(v -> v.anyValue(JsonData.of(val)))));
+                            }
+                            return new Query.Builder()
+                                    .match(MatchQuery.of(tq -> tq
+                                            .field(document.name())
+                                            .query(v -> v.anyValue(JsonData.of(val)))));
+                        })
                         .reduce((d1, d2) -> new Query.Builder()
                                 .bool(BoolQuery.of(bq -> bq
                                         .should(List.of(d1.build(), d2.build())))))
@@ -134,7 +178,7 @@ final class QueryConverter {
                 return document.get(new TypeReference<List<DocumentCondition>>() {
                         })
                         .stream()
-                        .map(d -> getCondition(d, ids))
+                        .map(d -> getCondition(indexMappingRecord, d))
                         .filter(Objects::nonNull)
                         .reduce((d1, d2) -> (Query.Builder) new Query.Builder()
                                 .bool(BoolQuery.of(bq -> bq
@@ -145,7 +189,7 @@ final class QueryConverter {
                 return document.get(new TypeReference<List<DocumentCondition>>() {
                         })
                         .stream()
-                        .map(d -> getCondition(d, ids))
+                        .map(d -> getCondition(indexMappingRecord, d))
                         .filter(Objects::nonNull)
                         .reduce((d1, d2) -> (Query.Builder) new Query.Builder()
                                 .bool(BoolQuery.of(bq -> bq
@@ -153,7 +197,7 @@ final class QueryConverter {
                         .orElseThrow(() -> new IllegalStateException("An and condition cannot be empty"));
             case NOT:
                 DocumentCondition dc = document.get(DocumentCondition.class);
-                Query.Builder queryBuilder = Optional.ofNullable(getCondition(dc, ids))
+                Query.Builder queryBuilder = Optional.ofNullable(getCondition(indexMappingRecord, dc))
                         .orElseThrow(() -> new IllegalStateException("An and condition cannot be empty"));
                 return (Query.Builder) new Query.Builder()
                         .bool(BoolQuery.of(bq -> bq

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterResult.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterResult.java
@@ -17,33 +17,20 @@ package org.eclipse.jnosql.databases.elasticsearch.communication;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
-import java.util.List;
-
 class QueryConverterResult {
 
     private final Query.Builder statement;
 
-    private final List<String> ids;
-
-    QueryConverterResult(Query.Builder statement, List<String> ids) {
+    QueryConverterResult(Query.Builder statement) {
         this.statement = statement;
-        this.ids = ids;
     }
 
     Query.Builder getStatement() {
         return statement;
     }
 
-    List<String> getIds() {
-        return ids;
-    }
-
-    public boolean hasId() {
-        return !ids.isEmpty();
-    }
-
     public boolean hasStatement() {
-        return statement != null || ids.isEmpty();
+        return statement != null;
     }
 
     public boolean hasQuery() {

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentDatabase.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentDatabase.java
@@ -68,11 +68,9 @@ public enum DocumentDatabase implements Supplier<ElasticsearchDocumentManagerFac
                         .isTrue();
             });
         } catch (Exception e) {
-            if( e instanceof ElasticsearchException){
-                e.printStackTrace();
-                return;
+            if( !(e instanceof ElasticsearchException)) {
+                throw new RuntimeException(e);
             }
-            throw new RuntimeException(e);
         }
     }
 

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentDatabase.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentDatabase.java
@@ -14,13 +14,31 @@
  */
 package org.eclipse.jnosql.databases.elasticsearch.communication;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
+import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
+import co.elastic.clients.elasticsearch.indices.PutMappingResponse;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.util.ObjectBuilder;
 import org.eclipse.jnosql.communication.Settings;
+import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 public enum DocumentDatabase implements Supplier<ElasticsearchDocumentManagerFactory> {
 
@@ -31,25 +49,113 @@ public enum DocumentDatabase implements Supplier<ElasticsearchDocumentManagerFac
                     .withReuse(true)
                     .withExposedPorts(9200, 9300)
                     .withEnv("discovery.type", "single-node")
-                    .withEnv("ES_JAVA_OPTS","-Xms1g -Xmx1g")
-                    .withEnv("xpack.security.enabled","false")
+                    .withEnv("ES_JAVA_OPTS", "-Xms1g -Xmx1g")
+                    .withEnv("xpack.security.enabled", "false")
                     .waitingFor(Wait.forHttp("/")
                             .forPort(9200)
                             .forStatusCode(200));
+
     {
         es.start();
+    }
+
+    public static void clearDatabase(String index) {
+        try (var elasticsearch = INSTANCE.newElasticsearchClient()) {
+            var response = elasticsearch.client().indices().delete(DeleteIndexRequest.of(d ->
+                    d.index(index)));
+            assertSoftly(softly -> {
+                softly.assertThat(response.acknowledged())
+                        .isTrue();
+            });
+        } catch (Exception e) {
+            if( e instanceof ElasticsearchException){
+                e.printStackTrace();
+                return;
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void createDatabase(String index) {
+        try (var elasticsearch = INSTANCE.newElasticsearchClient()) {
+            CreateIndexResponse response = elasticsearch.client().indices().create(
+                    CreateIndexRequest.of(b -> b.index(index)));
+            assertSoftly(softly -> {
+                softly.assertThat(response.acknowledged())
+                        .isTrue();
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void updateMapping(String index, Function<PutMappingRequest.Builder, ObjectBuilder<PutMappingRequest>> fn) {
+        try (var elasticsearch = INSTANCE.newElasticsearchClient()) {
+            PutMappingResponse response = elasticsearch.client().indices().putMapping(fn);
+            assertSoftly(softly -> {
+                softly.assertThat(response.acknowledged())
+                        .isTrue();
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void insertData(String index, Map<String, Object> map) {
+        try (var elasticsearch = INSTANCE.newElasticsearchClient()) {
+            var _id = Optional.ofNullable(map.remove("_id"));
+
+            var indexRequest = _id
+                    .map(String.class::cast)
+                    .map(id -> IndexRequest.of(b ->
+                            b.index(index)
+                                    .id(id).document(JsonData.of(map))))
+                    .orElseGet(() -> IndexRequest.of(b ->
+                            b.index(index).document(JsonData.of(map))));
+
+            IndexResponse response = elasticsearch.client().index(indexRequest);
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.result().jsonValue())
+                        .isEqualTo("created");
+            });
+            _id.ifPresent(id -> map.put("_id", id));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
 
     @Override
     public ElasticsearchDocumentManagerFactory get() {
         ElasticsearchDocumentConfiguration configuration = new ElasticsearchDocumentConfiguration();
-        Map<String, Object> settings = new HashMap<>();
-        settings.put(ElasticsearchConfigurations.HOST.get()+".1", host());
-        return configuration.apply(Settings.of(settings));
+        Settings settings1 = getSettings();
+        return configuration.apply(settings1);
     }
 
-    public ElasticsearchDocumentManager get(String database){
+    @NotNull
+    public Settings getSettings() {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put(ElasticsearchConfigurations.HOST.get() + ".1", host());
+        return Settings.of(settings);
+    }
+
+    public ElasticsearchClientAutoClosable newElasticsearchClient() {
+        ElasticsearchDocumentConfiguration configuration = new ElasticsearchDocumentConfiguration();
+        return new ElasticsearchClientAutoClosable(configuration.buildElasticsearchClient(getSettings()));
+    }
+
+    public static record ElasticsearchClientAutoClosable(
+            ElasticsearchClient client) implements AutoCloseable {
+
+        @Override
+        public void close() throws Exception {
+            this.client._transport().close();
+        }
+    }
+
+    public ElasticsearchDocumentManager get(String database) {
         ElasticsearchDocumentManagerFactory managerFactory = get();
         return managerFactory.apply(database);
     }

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ * Contributors:
+ *
+ * Maximillian Arruda
+ *
+ */
+
+package org.eclipse.jnosql.databases.elasticsearch.communication;
+
+import co.elastic.clients.elasticsearch._types.mapping.KeywordProperty;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord;
+import co.elastic.clients.util.ObjectBuilder;
+import jakarta.nosql.Column;
+import jakarta.nosql.Id;
+import org.awaitility.Awaitility;
+import org.eclipse.jnosql.communication.document.DocumentCondition;
+import org.eclipse.jnosql.communication.document.DocumentQuery;
+import org.eclipse.jnosql.mapping.config.MappingConfigurations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+class QueryConverterTest {
+
+    private static final String INDEX = QueryConverterTest.class.getSimpleName().toLowerCase();
+
+    static {
+        System.setProperty(ElasticsearchConfigurations.HOST.get() + ".1", DocumentDatabase.INSTANCE.host());
+        System.setProperty(MappingConfigurations.DOCUMENT_DATABASE.get(), INDEX);
+        Awaitility.setDefaultPollDelay(100, MILLISECONDS);
+        Awaitility.setDefaultTimeout(2L, SECONDS);
+    }
+
+    private DocumentDatabase.ElasticsearchClientAutoClosable elasticsearch;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        this.elasticsearch = DocumentDatabase.INSTANCE.newElasticsearchClient();
+        clearDatabase();
+    }
+
+    @AfterEach
+    void clearDatabase() throws IOException {
+        DocumentDatabase.clearDatabase(INDEX);
+    }
+
+
+    public static record Book(
+            @Id
+            String id,
+            @Column
+            String name,
+            @Column
+            Integer edition) {
+    }
+
+    final Book effectiveJava = new Book(
+            "6eaeafcd-3e6a-4ef6-9f5f-a1b33677850d",
+            "Effective Java",
+            1);
+
+    @Test
+    void testSupportTermQuery() throws Exception {
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", effectiveJava.name());
+        map.put("edition", effectiveJava.edition);
+        map.put("doc2", Map.of("data1", "teste", "data2", 333L));
+        map.put("@entity", Book.class.getSimpleName());
+
+        insertData(map);
+
+        IndexMappingRecord indexMappingRecordWithoutKeywordAttributes = elasticsearch.client().indices().getMapping(b -> b.index(INDEX)).get(INDEX);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(indexMappingRecordWithoutKeywordAttributes)
+                    .as("indexMappingRecordWithoutKeywordAttributes wasn't provided")
+                    .isNotNull();
+
+            map.keySet().forEach(key -> {
+                softly.assertThat(QueryConverter.supportTermQuery(indexMappingRecordWithoutKeywordAttributes, key))
+                        .as("%s attribute should not support TermQuery".formatted(key))
+                        .isFalse();
+            });
+
+            Set.of("doc2.data1", "doc2.data2").forEach(key -> {
+                softly.assertThat(QueryConverter.supportTermQuery(indexMappingRecordWithoutKeywordAttributes, key))
+                        .as("%s attribute should not support TermQuery".formatted(key))
+                        .isFalse();
+            });
+
+        });
+
+        clearDatabase();
+        recreateIndexWithKeywordFields(m ->
+                m.index(INDEX)
+                        .properties("@entity", f -> f.keyword(KeywordProperty.of(k -> k)))
+                        .properties("doc2", f -> f.object(o -> o.properties("data1", p -> p.keyword(KeywordProperty.of(k -> k)))))
+        );
+
+        insertData(map);
+
+        IndexMappingRecord indexMappingRecordWithKeywordAttributes = elasticsearch.client().indices().getMapping(b -> b.index(INDEX)).get(INDEX);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(indexMappingRecordWithKeywordAttributes)
+                    .as("indexMappingRecordWithKeywordAttributes wasn't provided")
+                    .isNotNull();
+
+            map.keySet().stream()
+                    .filter(anObject -> !"@entity".equals(anObject))
+                    .forEach(key -> {
+                        softly.assertThat(QueryConverter.supportTermQuery(indexMappingRecordWithKeywordAttributes, key))
+                                .as("%s attribute should not support TermQuery".formatted(key))
+                                .isFalse();
+
+                    });
+
+
+            softly.assertThat(QueryConverter.supportTermQuery(indexMappingRecordWithKeywordAttributes, "@entity"))
+                    .as("%s attribute should support TermQuery".formatted("@entity"))
+                    .isTrue();
+
+
+            softly.assertThat(QueryConverter.supportTermQuery(indexMappingRecordWithKeywordAttributes, "doc2.data1"))
+                    .as("%s attribute should not support TermQuery".formatted("doc2.data1"))
+                    .isTrue();
+
+            softly.assertThat(QueryConverter.supportTermQuery(indexMappingRecordWithKeywordAttributes, "doc2.data2"))
+                    .as("%s attribute should not support TermQuery".formatted("doc2.data2"))
+                    .isFalse();
+
+        });
+
+    }
+
+    @Test
+    void testSelect() throws Exception {
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("_id", effectiveJava.id());
+        map.put("name", effectiveJava.name());
+        map.put("edition", effectiveJava.edition());
+        map.put("doc2", Map.of("data1", "teste", "data2", 333L));
+        map.put("@entity", Book.class.getSimpleName());
+
+        insertData(map);
+
+        DocumentQuery query = DocumentQuery.builder()
+                .select()
+                .from("Book")
+                .where(DocumentCondition.eq("_id", effectiveJava.id())).build();
+
+        QueryConverterResult selectWithoutKeywordFields = QueryConverter.select(elasticsearch.client(), INDEX, query);
+
+        assertSoftly(softly -> {
+            softly.assertThat(selectWithoutKeywordFields)
+                    .as("QueryConverter.select() should returns a non-null object")
+                    .isNotNull();
+
+            Query _query = selectWithoutKeywordFields.getStatement().build();
+            softly.assertThat(_query._kind())
+                    .as("QueryConverterResult's statement should be a %s query".formatted(Query.Kind.Bool))
+                    .isEqualTo(Query.Kind.Bool);
+
+            softly.assertThat(_query.bool().must())
+                    .as("QueryConverterResult's statement should be a %s query with 2 conditions".formatted(Query.Kind.Bool))
+                    .hasSize(2);
+
+            softly.assertThat(_query.bool().must().get(0)._kind())
+                    .as("first condition of QueryConverterResult's statement should be a %s query".formatted(Query.Kind.Match))
+                    .isEqualTo(Query.Kind.Match);
+
+            softly.assertThat(_query.bool().must().get(1)._kind())
+                    .as("second condition of QueryConverterResult's statement should be a %s query".formatted(Query.Kind.Match))
+                    .isEqualTo(Query.Kind.Match);
+
+        });
+
+        System.out.println(selectWithoutKeywordFields);
+
+        clearDatabase();
+        recreateIndexWithKeywordFields(m ->
+                m.index(INDEX)
+                        .properties("@entity", f -> f.keyword(KeywordProperty.of(k -> k)))
+                        .properties("name", f -> f.keyword(KeywordProperty.of(k -> k)))
+                        .properties("edition", f -> f.keyword(KeywordProperty.of(k -> k)))
+                        .properties("doc2", f -> f.object(o -> o.properties("data1", p -> p.keyword(KeywordProperty.of(k -> k)))))
+        );
+
+        insertData(map);
+
+        DocumentQuery query2 = DocumentQuery.builder()
+                .select()
+                .from("Book")
+                .where(DocumentCondition.eq("_id", effectiveJava.id())
+                        .and(DocumentCondition.eq("doc2.data1", "teste")
+                                .and(DocumentCondition.eq("doc2.data2", 222L)))).build();
+
+        QueryConverterResult selectWithKeywordFields = QueryConverter.select(elasticsearch.client(), INDEX, query2);
+
+        assertSoftly(softly -> {
+            softly.assertThat(selectWithKeywordFields)
+                    .as("QueryConverter.select() should returns a non-null object")
+                    .isNotNull();
+
+            Query builtQuery = selectWithKeywordFields.getStatement().build();
+
+            softly.assertThat(builtQuery._kind())
+                    .as("QueryConverterResult's statement should be a %s query".formatted(Query.Kind.Bool))
+                    .isEqualTo(Query.Kind.Bool);
+
+            softly.assertThat(builtQuery.bool().must())
+                    .as("QueryConverterResult's statement should be a %s query".formatted(Query.Kind.Bool))
+                    .hasSize(2);
+
+            Query firstCondition = builtQuery.bool().must().get(0);
+            softly.assertThat(firstCondition._kind())
+                    .as("QueryConverterResult's statement's first condition should be a %s query".formatted(Query.Kind.Term))
+                    .isEqualTo(Query.Kind.Term);
+
+            Query secondCondition = builtQuery.bool().must().get(1);
+            softly.assertThat(secondCondition._kind())
+                    .as("QueryConverterResult's statement's second condition should be a %s query".formatted(Query.Kind.Bool))
+                    .isEqualTo(Query.Kind.Bool);
+
+            softly.assertThat(secondCondition.bool().must())
+                    .as("QueryConverterResult's statement should be a %s query".formatted(Query.Kind.Term))
+                    .hasSize(2);
+
+            Query firstSubConditionOfSecondCondition = secondCondition.bool().must().get(0);
+            softly.assertThat(firstSubConditionOfSecondCondition._kind())
+                    .as("first sub-condition of QueryConverterResult's statement's second condition should be a %s query".formatted(Query.Kind.Match))
+                    .isEqualTo(Query.Kind.Match);
+
+            Query secondSubConditionOfSecondCondition = secondCondition.bool().must().get(1);
+            softly.assertThat(secondSubConditionOfSecondCondition._kind())
+                    .as("second sub-condition of QueryConverterResult's statement's second condition should be a %s query".formatted(Query.Kind.Bool))
+                    .isEqualTo(Query.Kind.Bool);
+
+            softly.assertThat(secondSubConditionOfSecondCondition.bool().must())
+                    .as("second sub-condition of QueryConverterResult's statement's second condition should has wrong size")
+                    .hasSize(2);
+
+
+            Query firstSubSubConditionOfSecondCondition = secondSubConditionOfSecondCondition.bool().must().get(0);
+            softly.assertThat(firstSubSubConditionOfSecondCondition._kind())
+                    .as("first sub-condition of the second sub-condition of QueryConverterResult's statement's second condition should be a %s query".formatted(Query.Kind.Term))
+                    .isEqualTo(Query.Kind.Term);
+
+            Query secondSubSubConditionOfSecondCondition = secondSubConditionOfSecondCondition.bool().must().get(1);
+            softly.assertThat(secondSubSubConditionOfSecondCondition._kind())
+                    .as("second sub-condition of the second sub-condition of QueryConverterResult's statement's second condition should be a %s query".formatted(Query.Kind.Match))
+                    .isEqualTo(Query.Kind.Match);
+
+        });
+
+    }
+
+    private void recreateIndexWithKeywordFields(Function<PutMappingRequest.Builder, ObjectBuilder<PutMappingRequest>> fn) {
+        DocumentDatabase.createDatabase(INDEX);
+        DocumentDatabase.updateMapping(INDEX, fn);
+    }
+
+    private void insertData(Map<String, Object> map) throws IOException {
+        DocumentDatabase.insertData(INDEX, map);
+    }
+}

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Author.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Author.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ * Contributors:
+ *
+ * Maximillian Arruda
+ *
+ */
+
+package org.eclipse.jnosql.databases.elasticsearch.integration;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+
+import java.util.Objects;
+
+@Entity
+public final class Author {
+
+    @Column("name")
+    private final String name;
+
+    public Author(
+            @Column("name")
+            String name) {
+        this.name = name;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Author) obj;
+        return Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "Author[" +
+                "name=" + name + ']';
+    }
+
+}

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Book.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Book.java
@@ -53,7 +53,7 @@ public final class Book {
     public Book updateEdition(int edition) {
         return new Book(this.id,
                 this.title,
-                this.edition + 1,
+                edition,
                 this.author);
     }
 

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Book.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Book.java
@@ -18,8 +18,85 @@ import jakarta.nosql.Column;
 import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
 
+import java.util.Objects;
+import java.util.UUID;
+
 @Entity
-public record Book(@Id String id, @Column("title") String title, @Column("edition") int edition) {
+public final class Book {
+    @Id
+    private final String id;
+    @Column("title")
+    private final String title;
+    @Column("edition")
+    private final int edition;
+    @Column("author")
+    private final Author author;
+
+    public Book(
+            @Id String id,
+            @Column("title") String title,
+            @Column("edition") int edition,
+            @Column("author") Author author) {
+        this.id = id;
+        this.title = title;
+        this.edition = edition;
+        this.author = author;
+    }
+
+    public Book newEdition() {
+        return new Book(UUID.randomUUID().toString(),
+                this.title,
+                this.edition + 1,
+                this.author);
+    }
+
+    public Book updateEdition(int edition) {
+        return new Book(this.id,
+                this.title,
+                this.edition + 1,
+                this.author);
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public int edition() {
+        return edition;
+    }
+
+    public Author author() {
+        return author;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Book) obj;
+        return Objects.equals(this.id, that.id) &&
+                Objects.equals(this.title, that.title) &&
+                this.edition == that.edition &&
+                Objects.equals(this.author, that.author);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, edition, author);
+    }
+
+    @Override
+    public String toString() {
+        return "Book[" +
+                "id=" + id + ", " +
+                "title=" + title + ", " +
+                "edition=" + edition + ", " +
+                "author=" + author + ']';
+    }
 
 
 }

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Library.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Library.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ * Contributors:
+ *
+ * Maximillian Arruda
+ *
+ */
+
+package org.eclipse.jnosql.databases.elasticsearch.integration;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+import java.util.stream.Stream;
+
+@Repository
+public interface Library extends CrudRepository<Book, String> {
+
+    @Query("select * from Book where author.name = @name")
+    Stream<Book> findByAuthorName(@Param("name") String name);
+
+    Stream<Book> findByTitleLike( String title);
+
+}

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/RepositoryIntegrationTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/RepositoryIntegrationTest.java
@@ -1,0 +1,219 @@
+/*
+ *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.elasticsearch.integration;
+
+
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.eclipse.jnosql.databases.elasticsearch.communication.DocumentDatabase;
+import org.eclipse.jnosql.databases.elasticsearch.communication.ElasticsearchConfigurations;
+import org.eclipse.jnosql.databases.elasticsearch.mapping.ElasticsearchTemplate;
+import org.eclipse.jnosql.mapping.Convert;
+import org.eclipse.jnosql.mapping.config.MappingConfigurations;
+import org.eclipse.jnosql.mapping.document.DocumentEntityConverter;
+import org.eclipse.jnosql.mapping.document.spi.DocumentExtension;
+import org.eclipse.jnosql.mapping.reflection.EntityMetadataExtension;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+
+@EnableAutoWeld
+@AddPackages(value = {Convert.class, DocumentEntityConverter.class})
+@AddPackages(Book.class)
+@AddPackages(ElasticsearchTemplate.class)
+@AddExtensions({EntityMetadataExtension.class,
+        DocumentExtension.class})
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+class RepositoryIntegrationTest {
+
+    public static final String INDEX = "library";
+
+    static {
+        DocumentDatabase instance = DocumentDatabase.INSTANCE;
+        instance.get("library");
+        System.setProperty(ElasticsearchConfigurations.HOST.get() + ".1", instance.host());
+        System.setProperty(MappingConfigurations.DOCUMENT_DATABASE.get(), INDEX);
+        Awaitility.setDefaultPollDelay(100, MILLISECONDS);
+        Awaitility.setDefaultTimeout(60L, SECONDS);
+    }
+
+
+    @Inject
+    private Library library;
+
+    @BeforeEach
+    @AfterEach
+    public void clearDatabase() {
+        DocumentDatabase.clearDatabase(INDEX);
+    }
+
+    @Test
+    public void shouldInsert() {
+        Author joshuaBloch = new Author("Joshua Bloch");
+        Book book = new Book(randomUUID().toString(), "Effective Java", 1, joshuaBloch);
+        library.save(book);
+
+        AtomicReference<Book> reference = new AtomicReference<>();
+        await().until(() -> {
+            Optional<Book> optional = library.findById(book.id());
+            optional.ifPresent(reference::set);
+            return optional.isPresent();
+        });
+        assertThat(reference.get()).isNotNull().isEqualTo(book);
+    }
+
+    @Test
+    public void shouldUpdate() {
+        Author joshuaBloch = new Author("Joshua Bloch");
+        Book book = new Book(randomUUID().toString(), "Effective Java", 1, joshuaBloch);
+        assertThat(library.save(book))
+                .isNotNull()
+                .isEqualTo(book);
+
+        Book updated = book.updateEdition(2);
+
+        assertThat(library.save(updated))
+                .isNotNull()
+                .isNotEqualTo(book);
+
+        AtomicReference<Book> reference = new AtomicReference<>();
+        await().until(() -> {
+            Optional<Book> optional = library.findById(book.id());
+            optional.ifPresent(reference::set);
+            return optional.isPresent();
+        });
+        assertThat(reference.get()).isNotNull().isEqualTo(updated);
+
+    }
+
+    @Test
+    public void shouldFindById() {
+        Author joshuaBloch = new Author("Joshua Bloch");
+        Book book = new Book(randomUUID().toString(), "Effective Java", 1, joshuaBloch);
+
+        assertThat(library.save(book))
+                .isNotNull()
+                .isEqualTo(book);
+
+        AtomicReference<Book> reference = new AtomicReference<>();
+        await().until(() -> {
+            Optional<Book> optional = library.findById(book.id());
+            optional.ifPresent(reference::set);
+            return optional.isPresent();
+        });
+
+        assertThat(reference.get()).isNotNull().isEqualTo(book);
+    }
+
+    @Test
+    public void shouldDelete() {
+        Author joshuaBloch = new Author("Joshua Bloch");
+        Book book = new Book(randomUUID().toString(), "Effective Java", 1, joshuaBloch);
+        assertThat(library.save(book))
+                .isNotNull()
+                .isEqualTo(book);
+
+
+        library.deleteById(book.id());
+
+        assertThat(library.findById(book.id()))
+                .isNotNull().isEmpty();
+    }
+
+
+    @Test
+    public void shouldFindByAuthorName() throws InterruptedException {
+        Author joshuaBloch = new Author("Joshua Bloch");
+        Book book = new Book(randomUUID().toString(), "Effective Java", 1, joshuaBloch);
+
+        Set<Book> expectedBooks = Set.of(book, book.newEdition(), book.newEdition());
+        library.saveAll(expectedBooks);
+
+        await().until(() ->
+                !library.findByAuthorName(book.author().name()).toList().isEmpty());
+
+        var books = library.findByAuthorName(book.author().name()).toList();
+        assertThat(books)
+                .hasSize(3);
+
+        assertThat(books)
+                .containsAll(expectedBooks);
+    }
+
+    @Test
+    public void shouldFindByTitleLike() throws InterruptedException {
+        Author joshuaBloch = new Author("Joshua Bloch");
+
+        Book effectiveJava1stEdition = new Book(randomUUID().toString(), "Effective Java", 1, joshuaBloch);
+        Book effectiveJava2ndEdition = effectiveJava1stEdition.newEdition();
+        Book effectiveJava3rdEdition = effectiveJava2ndEdition.newEdition();
+
+        Author elderMoraes = new Author("Elder Moraes");
+        Book jakartaEECookBook = new Book(randomUUID().toString(), "Jakarta EE CookBook", 1, elderMoraes);
+
+        Set<Book> allBooks = Set.of(jakartaEECookBook, effectiveJava1stEdition, effectiveJava2ndEdition, effectiveJava3rdEdition);
+
+        Set<Book> effectiveBooks = Set.of(effectiveJava1stEdition, effectiveJava2ndEdition, effectiveJava3rdEdition);
+
+        library.saveAll(allBooks);
+
+        AtomicReference<List<Book>> booksWithEffective = new AtomicReference<>();
+        await().until(() -> {
+            var books = library.findByTitleLike("Effective").toList();
+            booksWithEffective.set(books);
+            return !books.isEmpty();
+        });
+
+        AtomicReference<List<Book>> booksWithJa = new AtomicReference<>();
+        await().until(() -> {
+            var books = library.findByTitleLike("Ja*").toList();
+            booksWithJa.set(books);
+            return !books.isEmpty();
+        });
+
+        assertSoftly(softly -> {
+            assertThat(booksWithEffective.get())
+                    .as("returned book list with 'Effective' is not equals to the expected items ")
+                    .containsAll(effectiveBooks);
+        });
+
+
+        assertSoftly(softly -> {
+            assertThat(booksWithJa.get())
+                    .as("returned book list with 'Ja*' is not equals to the expected items ")
+                    .containsAll(allBooks);
+        });
+    }
+
+
+}


### PR DESCRIPTION
Ref: https://github.com/eclipse/jnosql/issues/386

## Changes

During the query execution, JNoSQL is going to detect if the given fields used in `EQUALS` query conditions support the Elasticsearch `Term` query condition, if it does then the `EQUALS` query condition will be converted to Elasticsearch `Term` query condition, otherwise such `EQUALS` query conditions will be converted to the Elasticsearch `Match` query condition.