### PR TITLE
Removed unnecessary attributes, constructor arguments and methods from the classes of the JNoSQL Database Cassandra Implementation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,11 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Changed
+
+- Removed unnecessary attribute and constructor argument from  `CassandraColumnManagerFactory` and from its dependent classes;
+
+
 == [1.0.0] - 2023-6-22
 
 === Changed

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactory.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactory.java
@@ -21,7 +21,6 @@ import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import org.eclipse.jnosql.communication.column.ColumnManagerFactory;
 
 import java.util.List;
-import java.util.concurrent.Executor;
 
 /**
  * The Cassandra implementation to {@link ColumnManagerFactory}
@@ -30,11 +29,8 @@ public class CassandraColumnManagerFactory implements ColumnManagerFactory {
 
     private final CqlSessionBuilder sessionBuilder;
 
-    private final Executor executor;
-
-    CassandraColumnManagerFactory(final CqlSessionBuilder sessionBuilder, List<String> queries, Executor executor) {
+    CassandraColumnManagerFactory(final CqlSessionBuilder sessionBuilder, List<String> queries) {
         this.sessionBuilder = sessionBuilder;
-        this.executor = executor;
         load(queries);
     }
 
@@ -46,7 +42,7 @@ public class CassandraColumnManagerFactory implements ColumnManagerFactory {
 
     @Override
     public CassandraColumnManager apply(String database) {
-        return new DefaultCassandraColumnManager(sessionBuilder.build(), executor, database);
+        return new DefaultCassandraColumnManager(sessionBuilder.build(), database);
     }
 
     @Override
@@ -57,7 +53,6 @@ public class CassandraColumnManagerFactory implements ColumnManagerFactory {
     public String toString() {
         final StringBuilder sb = new StringBuilder("CassandraColumnManagerFactory{");
         sb.append("cluster=").append(sessionBuilder);
-        sb.append(", executor=").append(executor);
         sb.append('}');
         return sb.toString();
     }

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfiguration.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfiguration.java
@@ -22,7 +22,6 @@ import org.eclipse.jnosql.communication.column.ColumnConfiguration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -39,8 +38,7 @@ public final class CassandraConfiguration implements ColumnConfiguration {
     private CassandraColumnManagerFactory getManagerFactory(Map<String, String> configurations) {
         requireNonNull(configurations);
         CassandraProperties properties = CassandraProperties.of(configurations);
-        ExecutorService executorService = properties.createExecutorService();
-        return new CassandraColumnManagerFactory(properties.createCluster(), properties.getQueries(), executorService);
+        return new CassandraColumnManagerFactory(properties.createCluster(), properties.getQueries());
     }
 
 

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraProperties.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraProperties.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 class CassandraProperties {
 
@@ -69,10 +67,6 @@ class CassandraProperties {
             builder.withAuthCredentials(user.orElse(""), password.orElse(""));
         }
         return builder;
-    }
-
-    public ExecutorService createExecutorService() {
-        return Executors.newCachedThreadPool();
     }
 
     public static CassandraProperties of(Map<String, String> configurations) {

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultCassandraColumnManager.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultCassandraColumnManager.java
@@ -32,7 +32,6 @@ import org.eclipse.jnosql.communication.column.ColumnQuery;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -44,13 +43,10 @@ class DefaultCassandraColumnManager implements CassandraColumnManager {
 
     private final CqlSession session;
 
-    private final Executor executor;
-
     private final String keyspace;
 
-    DefaultCassandraColumnManager(CqlSession session, Executor executor, String keyspace) {
+    DefaultCassandraColumnManager(CqlSession session, String keyspace) {
         this.session = session;
-        this.executor = executor;
         this.keyspace = keyspace;
     }
 


### PR DESCRIPTION
## Changes:

Removed from the classes of the JNoSQL Database Cassandra Implementation:

- Removed unnecessary attributes;
- Removed unnecessary constructor arguments;
- Removed unused methods from the classes of the JNoSQL Database Cassandra Implementation