### PR TITLE
Allow Oracle NoSQL database have multiple entities in the same structure with different ids.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 - Remove the `UDT`  annotation and use `Column` annotation instead.
 
+=== Fixed
+
+- Allow multiple entities at Oracle NoSQL appending the entity name with the id instead of only the id
+
 == [1.1.0] - 2023-02-05
 
 === Changed


### PR DESCRIPTION
# Changes


- Allow Oracle NoSQL database to have multiple entities in the same structure with different IDs.


⚠️ This is a breaking change impact at the database, once, it will modify the relationship with the id with Oracle NoSQL