### PR TITLE
Upgrade NoSQL drivers

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,7 +17,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Upgrade AraongDB driver to 7.7.1
 - Upgrade Couchbase to version 3.7.1
 - Upgrade dynamodb to version 2.27.2
-- Upgrade Elasticsearch to version 8.15.0
+- Upgrade Elasticsearch to version 8.14.3
 - Upgrade Hazelcast to version 5.5.0
 - Upgrade Hbase version to 2.6.0
 - Upgrade Infinispan to version 15.0.7.Final

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,22 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 - Include between query support at MongoDB
 
+=== Changed
+
+- Upgrade AraongDB driver to 7.7.1
+- Upgrade Couchbase to version 3.7.1
+- Upgrade dynamodb to version 2.27.2
+- Upgrade Elasticsearch to version 8.15.0
+- Upgrade Hazelcast to version 5.5.0
+- Upgrade Hbase version to 2.6.0
+- Upgrade Infinispan to version 15.0.7.Final
+- Upgrade MongoDB to version 5.1.3
+- Upgrade Oracle NoSQL to version 5.4.15
+- Upgrade OrientDB to version 3.2.32
+- Upgrade Redis to version 5.1.4
+- Upgrade Solr to version 9.6.1
+
+
 == [1.1.1] - 2023-05-25
 
 === Changed

--- a/jnosql-arangodb/pom.xml
+++ b/jnosql-arangodb/pom.xml
@@ -28,7 +28,7 @@
     <description>The Eclipse JNoSQL layer to ArangoDB</description>
 
     <properties>
-        <arango.driver>7.6.0</arango.driver>
+        <arango.driver>7.7.1</arango.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverter.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverter.java
@@ -20,9 +20,9 @@ import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.CollectionFieldMetadata;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.metadata.FieldMetadata;
-import org.eclipse.jnosql.mapping.metadata.GenericFieldMetadata;
 import org.eclipse.jnosql.mapping.semistructured.AttributeFieldValue;
 import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 
@@ -74,7 +74,7 @@ class CassandraColumnEntityConverter extends EntityConverter {
             Object columns = udt.get();
             if (StreamSupport.stream(Iterable.class.cast(columns).spliterator(), false)
                     .allMatch(Iterable.class::isInstance)) {
-                GenericFieldMetadata genericField = GenericFieldMetadata.class.cast(field);
+                CollectionFieldMetadata genericField = CollectionFieldMetadata.class.cast(field);
                 Collection collection = genericField.collectionInstance();
                 List<List<Element>> embeddable = (List<List<Element>>) columns;
                 for (List<Element> columnList : embeddable) {

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverter.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverter.java
@@ -74,11 +74,11 @@ class CassandraColumnEntityConverter extends EntityConverter {
             Object columns = udt.get();
             if (StreamSupport.stream(Iterable.class.cast(columns).spliterator(), false)
                     .allMatch(Iterable.class::isInstance)) {
-                CollectionFieldMetadata genericField = CollectionFieldMetadata.class.cast(field);
-                Collection collection = genericField.collectionInstance();
+                var collectionFieldMetadata = CollectionFieldMetadata.class.cast(field);
+                Collection collection = collectionFieldMetadata.collectionInstance();
                 List<List<Element>> embeddable = (List<List<Element>>) columns;
                 for (List<Element> columnList : embeddable) {
-                    Object element = toEntity(genericField.elementType(), columnList);
+                    Object element = toEntity(collectionFieldMetadata.elementType(), columnList);
                     collection.add(element);
                 }
                 field.write(instance, collection);

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.6.2</version>
+            <version>3.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -22,7 +22,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.23.12</dynamodb.version>
+        <dynamodb.version>2.27.2</dynamodb.version>
     </properties>
 
     <dependencies>

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -28,7 +28,7 @@
     <description>The Eclipse JNoSQL layer to Elasticsearch</description>
 
     <properties>
-        <elasticsearch-java.version>8.13.4</elasticsearch-java.version>
+        <elasticsearch-java.version>8.15.0</elasticsearch-java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -28,7 +28,7 @@
     <description>The Eclipse JNoSQL layer to Elasticsearch</description>
 
     <properties>
-        <elasticsearch-java.version>8.15.0</elasticsearch-java.version>
+        <elasticsearch-java.version>8.14.3</elasticsearch-java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -29,7 +29,6 @@
 
     <properties>
         <elasticsearch-java.version>8.13.4</elasticsearch-java.version>
-        <awaitility.version>4.2.0</awaitility.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-hazelcast/pom.xml
+++ b/jnosql-hazelcast/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.0</version>
         </dependency>
     </dependencies>
 

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.0</version>
         </dependency>
     </dependencies>
 

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -26,7 +26,7 @@
     <description>The Eclipse JNoSQL layer implementation for Infinispan</description>
 
     <properties>
-        <infinispan.version>15.0.3.Final</infinispan.version>
+        <infinispan.version>15.0.7.Final</infinispan.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -27,7 +27,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.1.0</monbodb.driver>
+        <monbodb.driver>5.1.3</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.oracle.nosql.sdk</groupId>
             <artifactId>nosqldriver</artifactId>
-            <version>5.4.14</version>
+            <version>5.4.15</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>3.2.28</version>
+            <version>3.2.32</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>5.1.0</version>
+            <version>5.1.4</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-solr/pom.xml
+++ b/jnosql-solr/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>9.6.0</version>
+            <version>9.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <testcontainers.version>1.19.8</testcontainers.version>
+        <testcontainers.version>1.20.1</testcontainers.version>
         <jnosql.test.integration>false</jnosql.test.integration>
     </properties>
 


### PR DESCRIPTION
## Changed

- Upgrade AraongDB driver to 7.7.1
- Upgrade Couchbase to version 3.7.1
- Upgrade dynamodb to version 2.27.2
- Upgrade Elasticsearch to version 8.15.0
- Upgrade Hazelcast to version 5.5.0
- Upgrade Hbase version to 2.6.0
- Upgrade Infinispan to version 15.0.7.Final
- Upgrade MongoDB to version 5.1.3
- Upgrade Oracle NoSQL to version 5.4.15
- Upgrade OrientDB to version 3.2.32
- Upgrade Redis to version 5.1.4
- Upgrade Solr to version 9.6.1