### PR TITLE
ArangoDB: fix AQL query generation with AND conditions

### DIFF
--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
@@ -157,7 +157,7 @@ final class QueryAQLConverter {
                     if (isFirstCondition(aql, counter)) {
                         aql.append(AND);
                     }
-                    definesCondition(dc, aql, params, entity, counter +1);
+                    definesCondition(dc, aql, params, entity, ++counter);
                 }
                 return;
             case OR:

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
@@ -16,16 +16,12 @@ package org.eclipse.jnosql.databases.arangodb.communication;
 
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.util.Map;
 
-import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
-import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class QueryAQLConverterTest {
 
     @Test


### PR DESCRIPTION
Fixed ArangoDB AQL query generation with AND conditions