### PR TITLE
ArangoDB: fix AQL query generation

### DIFF
--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
@@ -157,7 +157,7 @@ final class QueryAQLConverter {
                     if (isFirstCondition(aql, counter)) {
                         aql.append(AND);
                     }
-                    definesCondition(dc, aql, params, entity, counter +1);
+                    definesCondition(dc, aql, params, entity, ++counter);
                 }
                 return;
             case OR:

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Michele Rastelli
  */
 package org.eclipse.jnosql.databases.arangodb.communication;
 
@@ -38,6 +39,8 @@ final class QueryAQLConverter {
     private static final String REMOVE = " REMOVE ";
     private static final String RETURN = " RETURN ";
     private static final String SEPARATOR = " ";
+    private static final String START_EXPRESSION = "(";
+    private static final String END_EXPRESSION = ")";
     private static final String AND = " AND ";
     private static final String OR = " OR ";
     private static final String EQUALS = " == ";
@@ -173,7 +176,9 @@ final class QueryAQLConverter {
             case NOT:
                 CriteriaCondition documentCondition = document.get(CriteriaCondition.class);
                 aql.append(NOT);
+                aql.append(START_EXPRESSION);
                 definesCondition(documentCondition, aql, params, entity, ++counter);
+                aql.append(END_EXPRESSION);
                 return;
             default:
                 throw new IllegalArgumentException("The condition does not support in AQL: " + condition.condition());

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
@@ -16,16 +16,12 @@ package org.eclipse.jnosql.databases.arangodb.communication;
 
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.util.Map;
 
-import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
-import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class QueryAQLConverterTest {
 
     @Test

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
@@ -11,12 +11,14 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Michele Rastelli
  */
 package org.eclipse.jnosql.databases.arangodb.communication;
 
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
@@ -131,7 +133,7 @@ public class QueryAQLConverterTest {
         String aql = convert.query();
         Map<String, Object> values = convert.values();
         assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  NOT  c.name == @name RETURN c", aql);
+        assertEquals("FOR c IN collection FILTER  NOT ( c.name == @name) RETURN c", aql);
 
     }
 
@@ -150,7 +152,7 @@ public class QueryAQLConverterTest {
         assertEquals("Assis", values.get("city"));
         assertEquals("Otavio", values.get("name"));
         assertEquals("Lucas", values.get("name_1"));
-        assertEquals("FOR c IN collection FILTER  NOT  c.city == @city AND  c.name == @name OR  NOT  c.name == @name_1 RETURN c", aql);
+        assertEquals("FOR c IN collection FILTER  NOT ( c.city == @city) AND  c.name == @name OR  NOT ( c.name == @name_1) RETURN c", aql);
 
     }
 


### PR DESCRIPTION
## Fixed:
- execute `QueryAQLConverterTest` as unit test
- ArangoDB: fixed AQL query generation with AND conditions
- ArangoDB: fixed precedence of NOT operator in AQL query generation (see ref doc: https://docs.arangodb.com/3.12/aql/operators/#operator-precedence)