### PR TITLE
ArangoDB: refactoring to JsonB converter

### DIFF
--- a/jnosql-arangodb/pom.xml
+++ b/jnosql-arangodb/pom.xml
@@ -28,7 +28,7 @@
     <description>The Eclipse JNoSQL layer to ArangoDB</description>
 
     <properties>
-        <arango.driver>7.7.1</arango.driver>
+        <arango.driver>7.11.0</arango.driver>
     </properties>
     <dependencies>
         <dependency>
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>com.arangodb</groupId>
-            <artifactId>arangodb-java-driver</artifactId>
+            <artifactId>arangodb-java-driver-shaded</artifactId>
             <version>${arango.driver}</version>
         </dependency>
     </dependencies>

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBBucketManager.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBBucketManager.java
@@ -11,12 +11,14 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Michele Rastelli
  */
 package org.eclipse.jnosql.databases.arangodb.communication;
 
 
 import com.arangodb.ArangoDB;
-import com.arangodb.entity.BaseDocument;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 import jakarta.json.bind.Jsonb;
 import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.communication.driver.JsonbSupplier;
@@ -41,8 +43,9 @@ import static java.util.stream.StreamSupport.stream;
 public class ArangoDBBucketManager implements BucketManager {
 
 
+    private static final String KEY = "_key";
     private static final String VALUE = "_value";
-    private static final Function<BaseDocument, String> TO_JSON = e -> e.getAttribute(VALUE).toString();
+    private static final Function<JsonObject, String> TO_JSON = e -> e.getString(VALUE);
     private static final Jsonb JSONB = JsonbSupplier.getInstance().get();
 
     private final ArangoDB arangoDB;
@@ -66,14 +69,15 @@ public class ArangoDBBucketManager implements BucketManager {
     public <K, V> void put(K key, V value) throws NullPointerException {
         Objects.requireNonNull(key, "Key is required");
         Objects.requireNonNull(value, "value is required");
-        BaseDocument baseDocument = new BaseDocument();
-        baseDocument.setKey(key.toString());
-        baseDocument.addAttribute(VALUE, JSONB.toJson(value));
+        JsonObject jsonObject = Json.createObjectBuilder()
+                .add(KEY, key.toString())
+                .add(VALUE, JSONB.toJson(value))
+                .build();
         if (arangoDB.db(bucketName).collection(namespace).documentExists(key.toString())) {
             arangoDB.db(bucketName).collection(namespace).deleteDocument(key.toString());
         }
         arangoDB.db(bucketName).collection(namespace)
-                .insertDocument(baseDocument);
+                .insertDocument(jsonObject);
     }
 
     @Override
@@ -91,8 +95,8 @@ public class ArangoDBBucketManager implements BucketManager {
     @Override
     public <K> Optional<Value> get(K key) throws NullPointerException {
         Objects.requireNonNull(key, "Key is required");
-        BaseDocument entity = arangoDB.db(bucketName).collection(namespace)
-                .getDocument(key.toString(), BaseDocument.class);
+        JsonObject entity = arangoDB.db(bucketName).collection(namespace)
+                .getDocument(key.toString(), JsonObject.class);
 
         return ofNullable(entity)
                 .map(TO_JSON)
@@ -105,7 +109,7 @@ public class ArangoDBBucketManager implements BucketManager {
         return stream(keys.spliterator(), false)
                 .map(Object::toString)
                 .map(k -> arangoDB.db(bucketName).collection(namespace)
-                        .getDocument(k, BaseDocument.class))
+                        .getDocument(k, JsonObject.class))
                 .filter(Objects::nonNull)
                 .map(TO_JSON)
                 .map(ValueJSON::of)

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBConfiguration.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBConfiguration.java
@@ -11,25 +11,27 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Michele Rastelli
  */
 package org.eclipse.jnosql.databases.arangodb.communication;
 
 
 import com.arangodb.ArangoDB;
 import com.arangodb.entity.LoadBalancingStrategy;
+import com.arangodb.serde.ArangoSerde;
 import org.eclipse.jnosql.communication.Settings;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * The base to configuration both key-value and document on mongoDB.
+ * The base to configuration both key-value and document on ArangoDB.
  * To each configuration set, it will change both builder
  * {@link ArangoDB.Builder}
  */
 public abstract class ArangoDBConfiguration {
 
-
-    protected ArangoDB.Builder builder = new ArangoDB.Builder();
+    protected ArangoDB.Builder builder = new ArangoDB.Builder()
+            .serde(new JsonbSerde());
 
     /**
      * Adds a host in the arangodb builder
@@ -53,7 +55,6 @@ public abstract class ArangoDBConfiguration {
         requireNonNull(loadBalancingStrategy, "loadBalancingStrategy is required");
         builder.loadBalancingStrategy(loadBalancingStrategy);
     }
-
 
     /**
      * set the setTimeout
@@ -92,6 +93,21 @@ public abstract class ArangoDBConfiguration {
     }
 
     /**
+     * Set the ArangoDB serde for the user data. Note that the provided
+     * serde must support serializing and deserializing JsonP types,
+     * i.e. {@link jakarta.json.JsonValue} and its children.
+     * By default, the builder is configured to use {@link JsonbSerde};
+     * this setter allows overriding it, i.e. providing an instance of
+     * {@link JsonbSerde} that uses a specific {@link jakarta.json.bind.Jsonb}
+     * instance.
+     *
+     * @param serde the serde
+     */
+    public void setSerde(ArangoSerde serde) {
+        builder.serde(serde);
+    }
+
+    /**
      * Defines a new builder to sync ArangoDB
      *
      * @param builder the new builder
@@ -102,12 +118,10 @@ public abstract class ArangoDBConfiguration {
         this.builder = builder;
     }
 
-
     protected ArangoDB getArangoDB(Settings settings) {
         ArangoDBBuilderSync aragonDB = new ArangoDBBuilderSync(builder);
         ArangoDBBuilders.load(settings, aragonDB);
         return aragonDB.build();
     }
-
 
 }

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/DefaultArangoDBDocumentManager.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/DefaultArangoDBDocumentManager.java
@@ -19,6 +19,7 @@ import com.arangodb.ArangoDB;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.DocumentCreateEntity;
 import com.arangodb.entity.DocumentUpdateEntity;
+import jakarta.json.JsonObject;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
@@ -63,10 +64,10 @@ class DefaultArangoDBDocumentManager implements ArangoDBDocumentManager {
         requireNonNull(entity, "entity is required");
         String collectionName = entity.name();
         checkCollection(collectionName);
-        BaseDocument baseDocument = ArangoDBUtil.getBaseDocument(entity);
-        DocumentCreateEntity<Void> arandoDocument = arangoDB.db(database)
-                .collection(collectionName).insertDocument(baseDocument);
-        updateEntity(entity, arandoDocument.getKey(), arandoDocument.getId(), arandoDocument.getRev());
+        JsonObject jsonObject = ArangoDBUtil.toJsonObject(entity);
+        DocumentCreateEntity<Void> arangoDocument = arangoDB.db(database)
+                .collection(collectionName).insertDocument(jsonObject);
+        updateEntity(entity, arangoDocument.getKey(), arangoDocument.getId(), arangoDocument.getRev());
         return entity;
     }
 
@@ -79,10 +80,10 @@ class DefaultArangoDBDocumentManager implements ArangoDBDocumentManager {
                 .orElseThrow(() -> new IllegalArgumentException("The document does not provide" +
                         " the _id column"));
         feedKey(entity, id);
-        BaseDocument baseDocument = ArangoDBUtil.getBaseDocument(entity);
-        DocumentUpdateEntity<Void> arandoDocument = arangoDB.db(database)
-                .collection(collectionName).updateDocument(baseDocument.getKey(), baseDocument);
-        updateEntity(entity, arandoDocument.getKey(), arandoDocument.getId(), arandoDocument.getRev());
+        JsonObject jsonObject = ArangoDBUtil.toJsonObject(entity);
+        DocumentUpdateEntity<Void> arangoDocument = arangoDB.db(database)
+                .collection(collectionName).updateDocument(jsonObject.getString(KEY), jsonObject);
+        updateEntity(entity, arangoDocument.getKey(), arangoDocument.getId(), arangoDocument.getRev());
         return entity;
     }
 
@@ -124,8 +125,8 @@ class DefaultArangoDBDocumentManager implements ArangoDBDocumentManager {
         requireNonNull(query, "query is required");
         AQLQueryResult result = QueryAQLConverter.select(query);
         LOGGER.finest("Executing AQL: " + result.query());
-        ArangoCursor<BaseDocument> documents = arangoDB.db(database).query(result.query(),
-                BaseDocument.class,
+        ArangoCursor<JsonObject> documents = arangoDB.db(database).query(result.query(),
+                JsonObject.class,
                 result.values(), null);
 
         return StreamSupport.stream(documents.spliterator(), false)
@@ -146,10 +147,9 @@ class DefaultArangoDBDocumentManager implements ArangoDBDocumentManager {
     public Stream<CommunicationEntity> aql(String query, Map<String, Object> params) throws NullPointerException {
         requireNonNull(query, "query is required");
         requireNonNull(params, "values is required");
-        ArangoCursor<BaseDocument> result = arangoDB.db(database).query(query,BaseDocument.class, params, null);
+        ArangoCursor<JsonObject> result = arangoDB.db(database).query(query, JsonObject.class, params, null);
         return StreamSupport.stream(result.spliterator(), false)
                 .map(ArangoDBUtil::toEntity);
-
     }
 
     @Override

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/JsonbSerde.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/JsonbSerde.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Michele Rastelli
+ */
+package org.eclipse.jnosql.databases.arangodb.communication;
+
+import com.arangodb.serde.ArangoSerde;
+import jakarta.json.bind.Jsonb;
+import org.eclipse.jnosql.communication.driver.JsonbSupplier;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * ArangoDB user-data serde that serializes and deserializes user data using JSONB.
+ * This supports natively JsonP types, i.e. {@link jakarta.json.JsonValue} and its children.
+ */
+public class JsonbSerde implements ArangoSerde {
+
+    private final Jsonb jsonb;
+
+    public JsonbSerde() {
+        this(JsonbSupplier.getInstance().get());
+    }
+
+    /**
+     * Alternative constructor to provide {@link Jsonb} instance to use,
+     * i.e. using custom configuration, see {@link jakarta.json.bind.JsonbBuilder#create(jakarta.json.bind.JsonbConfig)}
+     * @param jsonb Jsonb
+     */
+    public JsonbSerde(Jsonb jsonb) {
+        this.jsonb = jsonb;
+    }
+
+    @Override
+    public byte[] serialize(Object value) {
+        return jsonb.toJson(value).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public <T> T deserialize(byte[] content, Class<T> type) {
+        return jsonb.fromJson(new String(content, StandardCharsets.UTF_8), type);
+    }
+
+}


### PR DESCRIPTION
## Changes:
- ArangoDB: use the shaded driver to avoid risk of transitive dependencies convergence problems
- ArangoDB: added JsonB serde to natively support serializing/deserializing to/from JsonP types, i.e. `jakarta.json.JsonValue` (see ref doc https://docs.arangodb.com/3.12/develop/drivers/java/reference-version-7/serialization)
- ArangoDB: refactored conversion to/from `CommunicationEntity` by using `jakarta.json.JsonObject` instead of `com.arangodb.entity.BaseDocument`
