### PR TITLE
[JNoSQL Redis Database API] - Fixed broken connection issue and added sentinel and cluster support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,12 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Added
+- Added Redis Sentinel and Redis Cluster configuration at JNoSQL Redis Database API
+
+=== Fixed
+- Fixed the broken connection issue at JNoSQL Redis Database API
+
 == [1.1.2] - 2023-09-15
 
 === Added

--- a/README.adoc
+++ b/README.adoc
@@ -1470,52 +1470,158 @@ You can use either the Maven or Gradle dependencies:
 
 === Configuration
 
-This API provides the ```RedisConfigurations``` class to programmatically establish the credentials.
-Please note that you can establish properties using the https://microprofile.io/microprofile-config/[MicroProfile Config] specification.
-
-[cols="Redis"]
-|===
-|Configuration property |Description
-
-|`jnosql.redis.host`
-|The database host
-
-|`jnosql.redis.port`
-|The database port
-
-|`jnosql.redis.timeout`
-|The redis timeout, the default value 2000 on milliseconds
-
-|`jnosql.redis.password`
-|The user's password
-
-|`jnosql.redis.database`
-|The redis database number, the default value is 0
-
-|`jnosql.redis.client.name`
-|The client's name
-
-|`jnosql.redis.max.total`
-|The value for the maxTotal configuration attribute for pools created with this configuration instance, the default value 1000.
-
-|`jnosql.redis.max.idle`
-|The value for the maxIdle configuration attribute for pools created with this configuration instance, the default value 10.
-
-|`jnosql.redis.min.idle`
-|The value for the minIdle configuration attribute for pools created with this configuration instance, the default value 1.
-
-|`jnosql.redis.max.wait.millis`
-|The value for the maxWait configuration attribute for pools created with this configuration instance, the default value 3000.
-
-|===
-
 This is an example using Redis's Key-Value API with MicroProfile Config.
+Please note that you can establish properties using the https://microprofile.io/microprofile-config/[MicroProfile Config] specification.
 
 [source,properties]
 ----
 jnosql.keyvalue.provider=org.eclipse.jnosql.databases.redis.communication.RedisConfiguration
 jnosql.keyvalue.database=heroes
 ----
+
+This API provides enum classes to programmatically establish the credentials as:
+
+- link:README.adoc#_single_node_configuration[`RedisConfigurations`] for single node configuration
++
+[source,properties]
+----
+# Single Node Configuration
+
+# by default the host is localhost
+jnosql.redis.host=localhost
+# by default the port is 6379
+jnosql.redis.port=6379
+# if you have user
+jnosql.redis.user=youruser
+# if you have password
+jnosql.redis.password=yourpassword
+----
+
+- link:README.adoc#_redis_sentinel_configuration[`RedisSentinelConfigurations`] for sentinel configuration
++
+[source,properties]
+----
+# Sentinel Configuration
+jnosql.redis.sentinel.hosts=host1:26379,host2:26379
+
+jnosql.redis.sentinel.master.name=masterName
+jnosql.redis.sentinel.master.user=masterUser
+jnosql.redis.sentinel.master.password=masterPassword
+#jnosql.redis.sentinel.master.ssl=false
+#jnosql.redis.sentinel.master.timeout=2000
+#jnosql.redis.sentinel.master.connection.timeout=2000
+#jnosql.redis.sentinel.master.socket.timeout=2000
+
+jnosql.redis.sentinel.slave.user=slaveUser
+jnosql.redis.sentinel.slave.password=slavePassword
+#jnosql.redis.sentinel.slave.ssl=false
+#jnosql.redis.sentinel.slave.timeout=2000
+#jnosql.redis.sentinel.slave.connection.timeout=2000
+#jnosql.redis.sentinel.slave.socket.timeout=2000
+----
+
+- link:README.adoc#_redis_sentinel_configuration[`RedisClusterConfigurations`] for cluster configuration
++
+[source,properties]
+----
+# Cluster Configuration
+
+jnosql.redis.cluster.hosts=host1:6379,host2:6379
+jnosql.redis.cluster.user=clusterUser
+jnosql.redis.cluster.password=clusterPassword
+jnosql.redis.cluster.client.name=clusterClientName
+jnosql.redis.cluster.max.attempts=5
+jnosql.redis.cluster.max.total.retries.duration=10000
+#jnosql.redis.cluster.ssl=false
+#jnosql.redis.cluster.timeout=2000
+#jnosql.redis.cluster.connection.timeout=2000
+#jnosql.redis.cluster.socket.timeout=2000
+----
+
+==== Single Node Configuration
+
+This API provides the `RedisConfigurations` class to programmatically establish the credentials.
+Please note that you can establish properties using the https://microprofile.io/microprofile-config/[MicroProfile Config] specification.
+
+[cols="2,2", options="header"]
+|===
+|Configuration property |Description
+
+|`jnosql.redis.host` |The database host
+|`jnosql.redis.port` |The database port
+|`jnosql.redis.timeout` |The redis timeout, the default value is 2000 milliseconds
+|`jnosql.redis.password` |The password's credential
+|`jnosql.redis.database` |The redis database number
+|`jnosql.redis.client.name` |The cluster client's name. The default value is 0.
+|`jnosql.redis.max.total` |The value for the maxTotal configuration attribute for pools created with this configuration instance. The default value is 1000.
+|`jnosql.redis.max.idle` |The value for the maxIdle configuration attribute for pools created with this configuration instance. The default value is 10.
+|`jnosql.redis.min.idle` |The value for the minIdle configuration attribute for pools created with this configuration instance. The default value is 1.
+|`jnosql.redis.max.wait.millis` |The value for the maxWait configuration attribute for pools created with this configuration instance. The default value is 3000 milliseconds.
+|`jnosql.redis.connection.timeout` |The connection timeout in milliseconds configuration attribute for the jedis client configuration created with this configuration instance.
+|`jnosql.redis.socket.timeout` |The socket timeout in milliseconds configuration attribute for the jedis client configuration with this configuration instance.
+|`jnosql.redis.user` |The user configuration attribute for the jedis client configuration with this configuration instance.
+|`jnosql.redis.ssl` |The ssl configuration attribute for the jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.protocol` |The protocol configuration attribute for the jedis client configuration with this configuration instance.
+|`jnosql.redis.clientset.info.config.disabled` |The clientset info disabled configuration attribute for the jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.clientset.info.config.libname.suffix` |The clientset info configuration libname suffix attribute for the jedis client configuration with this configuration instance.
+|===
+
+==== Redis Sentinel Configuration
+
+This API provides the `RedisSentinelConfigurations` class to programmatically establish the credentials.
+Please note that you can establish properties using the https://microprofile.io/microprofile-config/[MicroProfile Config] specification.
+
+[cols="2,2", options="header"]
+|===
+|Configuration Property |Description
+
+|`jnosql.redis.sentinel.hosts` |The value for the sentinel HOST:PORT (separated by comma) configuration attribute for the jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.master.name` |The value for the master name configuration attribute for the jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.master.client.name` |The master client's name, the default value is 0
+|`jnosql.redis.sentinel.slave.client.name` |The slave client's name, the default value is 0
+|`jnosql.redis.sentinel.master.timeout` |The master redis timeout, the default value is 2000 milliseconds
+|`jnosql.redis.sentinel.slave.timeout` |The slave redis timeout, the default value is 2000 milliseconds
+|`jnosql.redis.sentinel.master.connection.timeout` |The connection timeout in milliseconds configuration attribute for the master jedis client configuration created with this configuration instance.
+|`jnosql.redis.sentinel.slave.connection.timeout` |The connection timeout in milliseconds configuration attribute for the slave jedis client configuration created with this configuration instance.
+|`jnosql.redis.sentinel.master.socket.timeout` |The socket timeout in milliseconds configuration attribute for the master jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.slave.socket.timeout` |The socket timeout in milliseconds configuration attribute for the slave jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.master.user` |The user configuration attribute for the master jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.slave.user` |The user configuration attribute for the slave jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.master.password` |The password configuration attribute for the master jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.slave.password` |The password configuration attribute for the slave jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.master.ssl` |The ssl configuration attribute for the master jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.sentinel.slave.ssl` |The ssl configuration attribute for the slave jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.sentinel.master.protocol` |The protocol configuration attribute for the master jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.slave.protocol` |The protocol configuration attribute for the slave jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.master.clientset.info.config.disabled` |The clientset info disabled configuration attribute for the master jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.sentinel.slave.clientset.info.config.disabled` |The clientset info disabled configuration attribute for the slave jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.sentinel.master.clientset.info.config.libname.suffix` |The clientset info configuration libname suffix attribute for the master jedis client configuration with this configuration instance.
+|`jnosql.redis.sentinel.slave.clientset.info.config.libname.suffix` |The clientset info configuration libname suffix attribute for the slave jedis client configuration with this configuration instance.
+|===
+
+==== Redis Cluster Configuration
+
+This API provides the `RedisClusterConfigurations` class to programmatically establish the credentials.
+Please note that you can establish properties using the https://microprofile.io/microprofile-config/[MicroProfile Config] specification.
+
+[cols="2,2", options="header"]
+|===
+|Configuration Property |Description
+
+|`jnosql.redis.cluster.hosts` |The value for the sentinel HOST:PORT (separated by comma) configuration attribute for the jedis client configuration with this configuration instance.
+|`jnosql.redis.cluster.client.name` |The cluster client's name. The default value is 0.
+|`jnosql.redis.cluster.timeout` |The cluster redis timeout, the default value is 2000 milliseconds
+|`jnosql.redis.cluster.connection.timeout` |The connection timeout in milliseconds configuration attribute for the cluster jedis client configuration created with this configuration instance.
+|`jnosql.redis.cluster.socket.timeout` |The socket timeout in milliseconds configuration attribute for the cluster jedis client configuration with this configuration instance.
+|`jnosql.redis.cluster.user` |The user configuration attribute for the cluster jedis client configuration with this configuration instance.
+|`jnosql.redis.cluster.password` |The password configuration attribute for the cluster jedis client configuration with this configuration instance.
+|`jnosql.redis.cluster.ssl` |The ssl configuration attribute for the cluster jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.cluster.protocol` |The protocol configuration attribute for the cluster jedis client configuration with this configuration instance.
+|`jnosql.redis.cluster.clientset.info.config.disabled` |The clientset info disabled configuration attribute for the cluster jedis client configuration with this configuration instance. The default value is false.
+|`jnosql.redis.cluster.clientset.info.config.libname.suffix` |The clientset info configuration libname suffix attribute for the cluster jedis client configuration with this configuration instance.
+|`jnosql.redis.cluster.max.attempts` |The value for the max attempts configuration attribute for the cluster jedis client configuration with this configuration instance. Default is 5.
+|`jnosql.redis.cluster.max.total.retries.duration` |The value for the max total retries configuration attribute for the cluster jedis client configuration with this configuration instance. Default is 10000 milliseconds.
+|===
 
 === RedisBucketManagerFactory
 

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/Counter.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/Counter.java
@@ -23,6 +23,8 @@ import java.time.Duration;
 public interface Counter {
 
     /**
+     * Returns the counter value
+     *
      * @return The counter value
      */
     Number get();

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounter.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounter.java
@@ -14,7 +14,7 @@
  */
 package org.eclipse.jnosql.databases.redis.communication;
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -32,13 +32,12 @@ class DefaultCounter implements Counter {
 
     private final String key;
 
-    private Jedis jedis;
+    private final UnifiedJedis jedis;
 
-    DefaultCounter(String key, Jedis jedis) {
+    DefaultCounter(String key, UnifiedJedis jedis) {
         this.key = key;
         this.jedis = jedis;
     }
-
 
     @Override
     public Number get() {

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultRedisBucketManagerFactory.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultRedisBucketManagerFactory.java
@@ -16,7 +16,7 @@ package org.eclipse.jnosql.databases.redis.communication;
 
 import jakarta.json.bind.Jsonb;
 import org.eclipse.jnosql.communication.driver.JsonbSupplier;
-import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.util.List;
 import java.util.Map;
@@ -29,10 +29,10 @@ class DefaultRedisBucketManagerFactory implements RedisBucketManagerFactory {
 
     private static final Jsonb JSON = JsonbSupplier.getInstance().get();
 
-    private final JedisPool jedisPool;
+    private final UnifiedJedis jedis;
 
-    DefaultRedisBucketManagerFactory(JedisPool jedisPool) {
-        this.jedisPool = jedisPool;
+    DefaultRedisBucketManagerFactory(UnifiedJedis jedis) {
+        this.jedis = jedis;
     }
 
 
@@ -40,59 +40,59 @@ class DefaultRedisBucketManagerFactory implements RedisBucketManagerFactory {
     public RedisBucketManager apply(String bucketName) {
         requireNonNull(bucketName, "bucket name is required");
 
-        return new RedisBucketManager(bucketName, JSON, jedisPool.getResource());
+        return new RedisBucketManager(bucketName, JSON, jedis);
     }
 
     @Override
     public <T> List<T> getList(String bucketName, Class<T> clazz) {
         requireNonNull(bucketName, "bucket name is required");
         requireNonNull(clazz, "Class type is required");
-        return new RedisList<>(jedisPool.getResource(), clazz, bucketName);
+        return new RedisList<>(jedis, clazz, bucketName);
     }
 
     @Override
     public <T> Set<T> getSet(String bucketName, Class<T> clazz) {
         requireNonNull(bucketName, "bucket name is required");
         requireNonNull(clazz, "Class type is required");
-        return new RedisSet<>(jedisPool.getResource(), clazz, bucketName);
+        return new RedisSet<>(jedis, clazz, bucketName);
     }
 
     @Override
     public <T> Queue<T> getQueue(String bucketName, Class<T> clazz) {
         requireNonNull(bucketName, "bucket name is required");
         requireNonNull(clazz, "Class type is required");
-        return new RedisQueue<>(jedisPool.getResource(), clazz, bucketName);
+        return new RedisQueue<>(jedis, clazz, bucketName);
     }
 
     @Override
     public <K, V> Map<K, V> getMap(String bucketName, Class<K> keyValue, Class<V> valueValue) {
         requireNonNull(bucketName, "bucket name is required");
         requireNonNull(valueValue, "Class type is required");
-        return new RedisMap<>(jedisPool.getResource(), keyValue, valueValue, bucketName);
+        return new RedisMap<>(jedis, keyValue, valueValue, bucketName);
     }
 
     @Override
     public SortedSet getSortedSet(String key) throws NullPointerException {
         requireNonNull(key, "key is required");
-        return new DefaultSortedSet(jedisPool.getResource(), key);
+        return new DefaultSortedSet(jedis, key);
     }
 
     @Override
     public Counter getCounter(String key) throws NullPointerException {
         requireNonNull(key, "key is required");
-        return new DefaultCounter(key, jedisPool.getResource());
+        return new DefaultCounter(key, jedis);
     }
 
 
     @Override
     public void close() {
-        jedisPool.close();
+        jedis.close();
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("RedisBucketManagerFactory{");
-        sb.append("jedisPool=").append(jedisPool);
+        sb.append("jedisPool=").append(jedis);
         sb.append('}');
         return sb.toString();
     }

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSet.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSet.java
@@ -16,7 +16,7 @@
 package org.eclipse.jnosql.databases.redis.communication;
 
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.time.Duration;
 import java.util.List;
@@ -33,9 +33,9 @@ class DefaultSortedSet implements SortedSet {
     private static final int LAST_ELEMENT = -1;
     private String key;
 
-    private Jedis jedis;
+    private UnifiedJedis jedis;
 
-    DefaultSortedSet(Jedis jedis, String keyspace) {
+    DefaultSortedSet(UnifiedJedis jedis, String keyspace) {
         Objects.requireNonNull(jedis, "jedis is required");
         Objects.requireNonNull(keyspace, "keyspace is required");
         this.key = keyspace;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManager.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManager.java
@@ -21,7 +21,7 @@ import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.communication.driver.ValueJSON;
 import org.eclipse.jnosql.communication.keyvalue.BucketManager;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueEntity;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -38,9 +38,9 @@ public class RedisBucketManager implements BucketManager {
     private final String nameSpace;
     private final Jsonb jsonB;
 
-    private final Jedis jedis;
+    private final UnifiedJedis jedis;
 
-    RedisBucketManager(String nameSpace, Jsonb provider, Jedis jedis) {
+    RedisBucketManager(String nameSpace, Jsonb provider, UnifiedJedis jedis) {
         this.nameSpace = nameSpace;
         this.jsonB = provider;
         this.jedis = jedis;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
@@ -15,8 +15,6 @@
 
 package org.eclipse.jnosql.databases.redis.communication;
 
-import redis.clients.jedis.Protocol;
-
 import java.util.function.Supplier;
 
 /**

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.databases.redis.communication;
+
+import redis.clients.jedis.Protocol;
+
+import java.util.function.Supplier;
+
+/**
+ * An enumeration to show the available options to connect to the Redis database by cluster configuration.
+ * It implements {@link Supplier}, where its it returns the property name that might be
+ * overwritten by the system environment using Eclipse Microprofile or Jakarta Config API.
+ *
+ * @see org.eclipse.jnosql.communication.Settings
+ */
+public enum RedisClusterConfigurations implements Supplier<String> {
+    /**
+     * The value for the sentinel basic configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    CLUSTER("jnosql.redis.cluster"),
+    /**
+     * The value for the sentinel HOST:PORT (separated by comma) configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    CLUSTER_HOSTS("jnosql.redis.cluster.hosts"),
+    /**
+     * The cluster client's name. The default value is 0.
+     */
+    CLIENT_NAME("jnosql.redis.cluster.client.name"),
+    /**
+     * The cluster redis timeout. The default value is {@link Protocol#DEFAULT_TIMEOUT}
+     */
+    TIMEOUT("jnosql.redis.cluster.timeout"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the cluster jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link Protocol#DEFAULT_TIMEOUT}
+     */
+    CONNECTION_TIMEOUT("jnosql.redis.cluster.connection.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the cluster jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default is {@link Protocol#DEFAULT_TIMEOUT}
+     */
+    SOCKET_TIMEOUT("jnosql.redis.cluster.socket.timeout"),
+    /**
+     * The value for the user configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    USER("jnosql.redis.cluster.user"),
+    /**
+     * The value for the password configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    PASSWORD("jnosql.redis.cluster.password"),
+    /**
+     * The value for the ssl configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The ssl on {@link redis.clients.jedis.JedisClientConfig}, the default value is false.
+     */
+    SSL("jnosql.redis.cluster.ssl"),
+    /**
+     * The value for the protocol configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The protocol on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    REDIS_PROTOCOL("jnosql.redis.cluster.protocol"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    CLIENTSET_INFO_CONFIG_DISABLED("jnosql.redis.cluster.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the cluster jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.cluster.clientset.info.config.libname.suffix"),
+
+    /**
+     * The value for the max attempts configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * Default is {@link redis.clients.jedis.JedisCluster#DEFAULT_MAX_ATTEMPTS}
+     */
+    CLUSTER_MAX_ATTEMPTS("jnosql.redis.cluster.max.attempts"),
+    /**
+     * The value for the max total retries configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * Default is {@link RedisClusterConfigurations#SOCKET_TIMEOUT} * {@link RedisClusterConfigurations#CLUSTER_MAX_ATTEMPTS}
+     */
+    CLUSTER_MAX_TOTAL_RETRIES_DURATION("jnosql.redis.cluster.max.total.retries.duration");
+
+    private final String configuration;
+
+    RedisClusterConfigurations(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String get() {
+        return configuration;
+    }
+
+    public static enum ClusterConfigurationsResolver implements
+            RedisConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return RedisClusterConfigurations.CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return RedisClusterConfigurations.SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return RedisClusterConfigurations.CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return RedisClusterConfigurations.USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return RedisClusterConfigurations.PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return RedisClusterConfigurations.TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return RedisClusterConfigurations.SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return RedisClusterConfigurations.REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return RedisClusterConfigurations.CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return RedisClusterConfigurations.CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+
+}

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
  */
 public enum RedisClusterConfigurations implements Supplier<String> {
     /**
-     * The value for the sentinel basic configuration attribute for the jedis client configuration with this configuration instance.
+     * The key property that defines if the redis cluster configuration should be loaded
      */
     CLUSTER("jnosql.redis.cluster"),
     /**
@@ -40,19 +40,19 @@ public enum RedisClusterConfigurations implements Supplier<String> {
      */
     CLIENT_NAME("jnosql.redis.cluster.client.name"),
     /**
-     * The cluster redis timeout. The default value is {@link Protocol#DEFAULT_TIMEOUT}
+     * The cluster redis timeout, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT} on milliseconds
      */
     TIMEOUT("jnosql.redis.cluster.timeout"),
     /**
      * The value for the connection timeout in milliseconds configuration attribute for the cluster jedis client configuration
      * created with this configuration instance.
-     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link Protocol#DEFAULT_TIMEOUT}
+     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
      */
     CONNECTION_TIMEOUT("jnosql.redis.cluster.connection.timeout"),
     /**
      * The value for the socket timeout in milliseconds configuration attribute for the cluster jedis client configuration with
      * this configuration instance.
-     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default is {@link Protocol#DEFAULT_TIMEOUT}
+     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
      */
     SOCKET_TIMEOUT("jnosql.redis.cluster.socket.timeout"),
     /**
@@ -72,17 +72,20 @@ public enum RedisClusterConfigurations implements Supplier<String> {
     SSL("jnosql.redis.cluster.ssl"),
     /**
      * The value for the protocol configuration attribute for the cluster jedis client configuration with this configuration instance.
-     * The protocol on {@link redis.clients.jedis.JedisClientConfig}
+     * The ssl on {@link redis.clients.jedis.JedisClientConfig}. The default value is false.
+     * The default value is not defined.
      */
     REDIS_PROTOCOL("jnosql.redis.cluster.protocol"),
     /**
      * The value for the clientset info disabled configuration attribute for the cluster jedis client configuration with this configuration instance.
      * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}
+     * The default value is false.
      */
     CLIENTSET_INFO_CONFIG_DISABLED("jnosql.redis.cluster.clientset.info.config.disabled"),
     /**
      * The value for the clientset info configuration libname suffix attribute for the cluster jedis client configuration with this configuration instance.
      * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}
+     * The default value is not defined.
      */
     CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.cluster.clientset.info.config.libname.suffix"),
 

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisCollection.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisCollection.java
@@ -17,7 +17,7 @@ package org.eclipse.jnosql.databases.redis.communication;
 
 import jakarta.json.bind.Jsonb;
 import org.eclipse.jnosql.communication.driver.JsonbSupplier;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,13 +33,11 @@ abstract class RedisCollection<T> implements Collection<T> {
 
     protected final String keyWithNameSpace;
 
-    protected final Jedis jedis;
+    protected final UnifiedJedis jedis;
 
     protected final boolean isString;
 
-
-
-    RedisCollection(Jedis jedis, Class<T> clazz, String keyWithNameSpace) {
+    RedisCollection(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
         this.clazz = clazz;
         this.keyWithNameSpace = keyWithNameSpace;
         this.jedis = jedis;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
@@ -236,10 +236,4 @@ public final class RedisConfiguration implements KeyValueConfiguration {
         return poolConfig;
     }
 
-    public static void main(String[] args) {
-
-        Arrays.stream(RedisConfigurations.values())
-                .map(RedisConfigurations::get)
-                .forEach(System.out::println);
-    }
 }

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
@@ -67,13 +67,13 @@ public final class RedisConfiguration implements KeyValueConfiguration {
 
         if (settings.keySet()
                 .stream()
-                .anyMatch(s -> s.startsWith(RedisConfigurations.SENTINEL.get()))) {
+                .anyMatch(s -> s.startsWith(RedisSentinelConfigurations.SENTINEL.get()))) {
             return applyForSentinel(settings);
         }
 
         if (settings.keySet()
                 .stream()
-                .anyMatch(s -> s.startsWith(RedisConfigurations.CLUSTER.get()))) {
+                .anyMatch(s -> s.startsWith(RedisClusterConfigurations.CLUSTER.get()))) {
             return applyForCluster(settings);
         }
 

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
@@ -31,7 +31,6 @@ import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.UnifiedJedis;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurations.java
@@ -35,7 +35,7 @@ public enum RedisConfigurations implements Supplier<String> {
      */
     PORT("jnosql.redis.port"),
     /**
-     * The redis timeout, the default value 2000 on milliseconds
+     * The redis timeout, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT} on milliseconds
      */
     TIMEOUT("jnosql.redis.timeout"),
     /**
@@ -47,39 +47,39 @@ public enum RedisConfigurations implements Supplier<String> {
      */
     DATABASE("jnosql.redis.database"),
     /**
-     * The client's name
+     * The cluster client's name. The default value is 0.
      */
     CLIENT_NAME("jnosql.redis.client.name"),
     /**
      * The value for the maxTotal configuration attribute for pools created with this configuration instance.
-     * The max number of thread to {@link redis.clients.jedis.JedisPoolConfig}, the default value 1000
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MAX_TOTAL}
      */
     MAX_TOTAL("jnosql.redis.max.total"),
     /**
      * The value for the maxIdle configuration attribute for pools created with this configuration instance.
-     * The max idle {@link redis.clients.jedis.JedisPoolConfig}, the default value 10
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MAX_IDLE}
      */
     MAX_IDLE("jnosql.redis.max.idle"),
     /**
      * The value for the minIdle configuration attribute for pools created with this configuration instance.
-     * The min idle {@link redis.clients.jedis.JedisPoolConfig}, the default value 1
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MIN_IDLE}
      */
     MIN_IDLE("jnosql.redis.min.idle"),
     /**
      * The value for the {@code maxWait} configuration attribute for pools created with this configuration instance.
-     * The max wait on millis on {@link redis.clients.jedis.JedisPoolConfig}, the default value 3000
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MAX_WAIT_MILLIS}
      */
     MAX_WAIT_MILLIS("jnosql.redis.max.wait.millis"),
     /**
      * The value for the connection timeout in milliseconds configuration attribute for the jedis client configuration
      * created with this configuration instance.
-     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value 2000
+     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
      */
     CONNECTION_TIMEOUT("jnosql.redis.connection.timeout"),
     /**
      * The value for the socket timeout in milliseconds configuration attribute for the jedis client configuration with
      * this configuration instance.
-     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value 2000
+     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
      */
     SOCKET_TIMEOUT("jnosql.redis.socket.timeout"),
     /**
@@ -89,32 +89,27 @@ public enum RedisConfigurations implements Supplier<String> {
     USER("jnosql.redis.user"),
     /**
      * The value for the ssl configuration attribute for the jedis client configuration with this configuration instance.
-     * The ssl on {@link redis.clients.jedis.JedisClientConfig}
+     * The ssl on {@link redis.clients.jedis.JedisClientConfig}. The default value is false.
      */
     SSL("jnosql.redis.ssl"),
     /**
      * The value for the protocol configuration attribute for the jedis client configuration with this configuration instance.
-     * The protocol on {@link redis.clients.jedis.JedisClientConfig}
+     * The protocol on {@link redis.clients.jedis.JedisClientConfig}.
+     * The default value is not defined.
      */
     REDIS_PROTOCOL("jnosql.redis.protocol"),
     /**
      * The value for the clientset info disabled configuration attribute for the jedis client configuration with this configuration instance.
-     * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}
+     * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}.
+     * The default value is false.
      */
     CLIENTSET_INFO_CONFIG_DISABLED("jnosql.redis.clientset.info.config.disabled"),
     /**
      * The value for the clientset info configuration libname suffix attribute for the jedis client configuration with this configuration instance.
-     * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}
+     * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}.
+     * The default value is not defined.
      */
-    CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.clientset.info.config.libname.suffix"),
-    /**
-     * The value for the sentinel basic configuration attribute for the jedis client configuration with this configuration instance.
-     */
-    SENTINEL("jnosql.redis.sentinel"),
-    /**
-     * The value for the cluster configuration attribute for the jedis client configuration with this configuration instance.
-     */
-    CLUSTER("jnosql.redis.cluster");
+    CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.clientset.info.config.libname.suffix"),;
 
     private final String configuration;
 

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurations.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.databases.redis.communication;
 
 
-
 import java.util.function.Supplier;
 
 /**
@@ -44,7 +43,7 @@ public enum RedisConfigurations implements Supplier<String> {
      */
     PASSWORD("jnosql.redis.password"),
     /**
-     * The redis database number, the default value is 0
+     * The redis database number
      */
     DATABASE("jnosql.redis.database"),
     /**
@@ -70,7 +69,52 @@ public enum RedisConfigurations implements Supplier<String> {
      * The value for the {@code maxWait} configuration attribute for pools created with this configuration instance.
      * The max wait on millis on {@link redis.clients.jedis.JedisPoolConfig}, the default value 3000
      */
-    MAX_WAIT_MILLIS("jnosql.redis.max.wait.millis");
+    MAX_WAIT_MILLIS("jnosql.redis.max.wait.millis"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value 2000
+     */
+    CONNECTION_TIMEOUT("jnosql.redis.connection.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value 2000
+     */
+    SOCKET_TIMEOUT("jnosql.redis.socket.timeout"),
+    /**
+     * The value for the user configuration attribute for the jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    USER("jnosql.redis.user"),
+    /**
+     * The value for the ssl configuration attribute for the jedis client configuration with this configuration instance.
+     * The ssl on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    SSL("jnosql.redis.ssl"),
+    /**
+     * The value for the protocol configuration attribute for the jedis client configuration with this configuration instance.
+     * The protocol on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    REDIS_PROTOCOL("jnosql.redis.protocol"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    CLIENTSET_INFO_CONFIG_DISABLED("jnosql.redis.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.clientset.info.config.libname.suffix"),
+    /**
+     * The value for the sentinel basic configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    SENTINEL("jnosql.redis.sentinel"),
+    /**
+     * The value for the cluster configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    CLUSTER("jnosql.redis.cluster");
 
     private final String configuration;
 
@@ -81,5 +125,61 @@ public enum RedisConfigurations implements Supplier<String> {
     @Override
     public String get() {
         return configuration;
+    }
+
+    public static enum SingleRedisConfigurationsResolver
+            implements RedisConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return RedisConfigurations.CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return RedisConfigurations.SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return RedisConfigurations.CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return RedisConfigurations.USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return RedisConfigurations.PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return RedisConfigurations.TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return RedisConfigurations.SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return RedisConfigurations.REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return RedisConfigurations.CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return RedisConfigurations.CLIENTSET_INFO_CONFIG_DISABLED;
+        }
     }
 }

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationsResolver.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationsResolver.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.databases.redis.communication;
+
+import java.util.function.Supplier;
+
+public sealed interface RedisConfigurationsResolver permits
+        RedisConfigurations.SingleRedisConfigurationsResolver,
+        RedisClusterConfigurations.ClusterConfigurationsResolver,
+        RedisSentinelConfigurations.SentinelMasterConfigurationsResolver,
+        RedisSentinelConfigurations.SentinelSlaveConfigurationsResolver {
+
+    Supplier<String> connectionTimeoutSupplier();
+
+    Supplier<String> socketTimeoutSupplier();
+
+    Supplier<String> clientNameSupplier();
+
+    Supplier<String> userSupplier();
+
+    Supplier<String> passwordSupplier();
+
+    Supplier<String> timeoutSupplier();
+
+    Supplier<String> sslSupplier();
+
+    Supplier<String> redisProtocolSupplier();
+
+    Supplier<String> clientsetInfoConfigLibNameSuffixSupplier();
+
+    Supplier<String> clientsetInfoConfigDisabled();
+}

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisList.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisList.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.jnosql.databases.redis.communication;
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.args.ListPosition;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.Objects;
 class RedisList<T> extends RedisCollection<T> implements List<T> {
 
 
-    RedisList(Jedis jedis, Class<T> clazz, String keyWithNameSpace) {
+    RedisList(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
         super(jedis, clazz, keyWithNameSpace);
     }
 

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisMap.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisMap.java
@@ -17,7 +17,7 @@ package org.eclipse.jnosql.databases.redis.communication;
 
 import jakarta.json.bind.Jsonb;
 import org.eclipse.jnosql.communication.driver.JsonbSupplier;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -40,14 +40,13 @@ class RedisMap<K, V> implements Map<K, V> {
 
     private final String nameSpace;
 
-    private final Jedis jedis;
+    private final UnifiedJedis jedis;
 
     private final boolean isKeyString;
 
     private final boolean isValueString;
 
-
-    RedisMap(Jedis jedis, Class<K> keyValue, Class<V> valueClass, String keyWithNameSpace) {
+    RedisMap(UnifiedJedis jedis, Class<K> keyValue, Class<V> valueClass, String keyWithNameSpace) {
         this.keyClass = keyValue;
         this.valueClass = valueClass;
         this.nameSpace = keyWithNameSpace;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisQueue.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisQueue.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.jnosql.databases.redis.communication;
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -23,7 +23,7 @@ import java.util.Queue;
 
 class RedisQueue<T> extends RedisCollection<T> implements Queue<T> {
 
-    RedisQueue(Jedis jedis, Class<T> clazz, String keyWithNameSpace) {
+    RedisQueue(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
         super(jedis, clazz, keyWithNameSpace);
     }
 

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSentinelConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSentinelConfigurations.java
@@ -26,8 +26,8 @@ import java.util.function.Supplier;
  */
 public enum RedisSentinelConfigurations implements Supplier<String> {
     /**
-     * The value for the sentinel basic configuration attribute for the jedis client configuration with this configuration instance.
-     */
+     * The key property that defines if the redis sentinel configuration should be loaded
+     * */
     SENTINEL("jnosql.redis.sentinel"),
     /**
      * The value for the master name configuration attribute for the jedis client configuration with this configuration instance.

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSentinelConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSentinelConfigurations.java
@@ -1,0 +1,261 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.databases.redis.communication;
+
+import java.util.function.Supplier;
+
+/**
+ * An enumeration to show the available options to connect to the Redis database by Sentinel configuration .
+ * It implements {@link Supplier}, where its it returns the property name that might be
+ * overwritten by the system environment using Eclipse Microprofile or Jakarta Config API.
+ *
+ * @see org.eclipse.jnosql.communication.Settings
+ */
+public enum RedisSentinelConfigurations implements Supplier<String> {
+    /**
+     * The value for the sentinel basic configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    SENTINEL("jnosql.redis.sentinel"),
+    /**
+     * The value for the master name configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    SENTINEL_MASTER_NAME("jnosql.redis.sentinel.master.name"),
+    /**
+     * The value for the sentinel HOST:PORT (separated by comma) configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    SENTINEL_HOSTS("jnosql.redis.sentinel.hosts"),
+    /**
+     * The master client's name, the default value is 0
+     */
+    MASTER_CLIENT_NAME("jnosql.redis.sentinel.master.client.name"),
+    /**
+     * The slave client's name, the default value is 0
+     */
+    SLAVE_CLIENT_NAME("jnosql.redis.sentinel.slave.client.name"),
+    /**
+     * The master redis timeout, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT} on milliseconds
+     */
+    MASTER_TIMEOUT("jnosql.redis.sentinel.master.timeout"),
+    /**
+     * The slave redis timeout, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT} on milliseconds
+     */
+    SLAVE_TIMEOUT("jnosql.redis.sentinel.slave.timeout"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the master jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
+     */
+    MASTER_CONNECTION_TIMEOUT("jnosql.redis.sentinel.master.connection.timeout"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the slave jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
+     */
+    SLAVE_CONNECTION_TIMEOUT("jnosql.redis.sentinel.slave.connection.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the master jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
+     */
+    MASTER_SOCKET_TIMEOUT("jnosql.redis.sentinel.master.socket.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the slave jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link redis.clients.jedis.JedisClientConfig}, the default value is {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
+     */
+    SLAVE_SOCKET_TIMEOUT("jnosql.redis.sentinel.slave.socket.timeout"),
+    /**
+     * The value for the user configuration attribute for the master jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    MASTER_USER("jnosql.redis.sentinel.master.user"),
+    /**
+     * The value for the user configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    SLAVE_USER("jnosql.redis.sentinel.slave.user"),
+    /**
+     * The value for the password configuration attribute for the master jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    MASTER_PASSWORD("jnosql.redis.sentinel.master.password"),
+    /**
+     * The value for the password configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The user on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    SLAVE_PASSWORD("jnosql.redis.sentinel.slave.password"),
+    /**
+     * The value for the ssl configuration attribute for the master jedis client configuration with this configuration instance.
+     * The ssl on {@link redis.clients.jedis.JedisClientConfig}. The default value is false.
+     */
+    MASTER_SSL("jnosql.redis.sentinel.master.ssl"),
+    /**
+     * The value for the ssl configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The ssl on {@link redis.clients.jedis.JedisClientConfig}. The default value is false
+     */
+    SLAVE_SSL("jnosql.redis.sentinel.slave.ssl"),
+    /**
+     * The value for the protocol configuration attribute for the master jedis client configuration with this configuration instance.
+     * The protocol on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    MASTER_REDIS_PROTOCOL("jnosql.redis.sentinel.master.protocol"),
+    /**
+     * The value for the protocol configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The protocol on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    SLAVE_REDIS_PROTOCOL("jnosql.redis.sentinel.slave.protocol"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the master jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    MASTER_CLIENTSET_INFO_CONFIG_DISABLED("jnosql.redis.sentinel.master.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    SLAVE_CLIENTSET_INFO_CONFIG_DISABLED("jnosql.redis.sentinel.slave.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the master jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    MASTER_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.sentinel.master.clientset.info.config.libname.suffix"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the slave jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link redis.clients.jedis.JedisClientConfig}
+     */
+    SLAVE_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.redis.sentinel.slave.clientset.info.config.libname.suffix");
+
+    private final String configuration;
+
+    RedisSentinelConfigurations(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String get() {
+        return configuration;
+    }
+
+    public static enum SentinelMasterConfigurationsResolver implements RedisConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return RedisSentinelConfigurations.MASTER_CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return RedisSentinelConfigurations.MASTER_SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return RedisSentinelConfigurations.MASTER_CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return RedisSentinelConfigurations.MASTER_USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return RedisSentinelConfigurations.MASTER_PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return RedisSentinelConfigurations.MASTER_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return RedisSentinelConfigurations.MASTER_SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return RedisSentinelConfigurations.MASTER_REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return RedisSentinelConfigurations.MASTER_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return RedisSentinelConfigurations.MASTER_CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+
+    public static enum SentinelSlaveConfigurationsResolver implements RedisConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return RedisSentinelConfigurations.SLAVE_CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return RedisSentinelConfigurations.SLAVE_SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return RedisSentinelConfigurations.SLAVE_CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return RedisSentinelConfigurations.SLAVE_USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return RedisSentinelConfigurations.SLAVE_PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return RedisSentinelConfigurations.SLAVE_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return RedisSentinelConfigurations.SLAVE_SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return RedisSentinelConfigurations.SLAVE_REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return RedisSentinelConfigurations.SLAVE_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return RedisSentinelConfigurations.SLAVE_CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+}

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSet.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSet.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.jnosql.databases.redis.communication;
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.Set;
 
 class RedisSet<T> extends RedisCollection<T> implements Set<T> {
 
-    RedisSet(Jedis jedis, Class<T> clazz, String keyWithNameSpace) {
+    RedisSet(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
         super(jedis, clazz, keyWithNameSpace);
     }
 


### PR DESCRIPTION
## Changes

- [x] Fixes the [#560](https://github.com/eclipse/jnosql/issues/560) issue;
- [x] Fixes the [#534](https://github.com/eclipse/jnosql/issues/534) adding Redis Sentinel and Redis Cluster support;
- [x] Update the JNoSQL Redis Database API documentation;
- [x]  Redis sample project at https://github.com/jnosql/demos-ee -> https://github.com/JNOSQL/demos-ee/pull/18
